### PR TITLE
Add a DELETE route.

### DIFF
--- a/mystiko.py
+++ b/mystiko.py
@@ -30,7 +30,7 @@ from flask_uuid import FlaskUUID
 from werkzeug.exceptions import NotFound
 from flask_bcrypt import Bcrypt
 
-__version_tuple__ = (0, 2)
+__version_tuple__ = (0, 3)
 __version__ = '.'.join(str(i) for i in __version_tuple__)
 
 try:

--- a/mystiko.py
+++ b/mystiko.py
@@ -177,6 +177,17 @@ def set_item(item_id):
     return '', 204
 
 
+@app.route('/item/<uuid:item_id>', methods=['DELETE'])
+@auth_required
+def delete_item(item_id):
+    id_str = str(item_id)
+    item = Item.query.get(id_str)
+    if item is not None:
+        db.session.delete(item)
+        db.session.commit()
+    return '', 204
+
+
 def create_db():
     db.create_all()
 


### PR DESCRIPTION
This PR adds the ability to delete items by using the `DELETE` HTTP verb. Doing so will always return `204`, even if no item exists by the given id.
Fixes #2 